### PR TITLE
🐛 Centre city name and title correctly on the key

### DIFF
--- a/Sources/com.barraider.worldtime.sdPlugin/index.html
+++ b/Sources/com.barraider.worldtime.sdPlugin/index.html
@@ -83,10 +83,10 @@
                         var idx = cityName.indexOf("/") + 1;
                         cityNameShort = cityName.substring(idx).replace("_", " ");
                         if (cityNameShort.length > 6) {
-                            cityNameShort = cityNameShort.slice(0, 5) + "-\r\n" + cityNameShort.substring(5);
+                            cityNameShort = cityNameShort.slice(0, 5) + "-\n" + cityNameShort.substring(5);
                         }
                         else {
-                            cityNameShort = cityNameShort + "\r\n";
+                            cityNameShort = cityNameShort + "\n";
                         }
                     }
                     var offsetTime = getDateFromOffset(offsetMinutes);
@@ -174,7 +174,7 @@
                     }
 
                     if (showCityName || showTitle) {
-                        strTime = cityNameShort + "\r\n" + strTime;
+                        strTime = cityNameShort + "\n" + strTime;
                     }
                     this.SetTitle(context, strTime);
                 }


### PR DESCRIPTION
The carriage return character alongside the new line character was causing the text to become left-justified instead of centred.

Not 100% sure whether this was introduced in Stream Deck 5.0 as I believe there were no problems using `\r\n` beforehand.